### PR TITLE
default to enabled with option to disable.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.3.0 - 2014-01-12
+### Added
+- default to enabled with option to disable.
+- application name defaults to `package.name` + `-` + `process.env.NODE_ENV`.
+- dropped `env-allowed` package.
+- better documentation.
+- tests.
+
 ## 0.1.0 - 2014-12-15
 ### Added
 - extracted `env-allowed` and `env-accessor` modules.

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "tape": "^3.0.3"
   },
   "dependencies": {
+    "boolean": "0.0.1",
     "debug": "^2.1.0",
     "env-accessors": "^0.2.1",
-    "env-allowed": "^0.1.1",
     "newrelic": "^1.14.2",
     "package.root": "^0.2.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -8,60 +8,64 @@
 
 ## Why?
 
-So you don't have to do this:
+0. You avoid writing and maintaining the following:
 
-    if (process.env.NODE_ENV === 'production') {
-      require('newrelic');
-    }
+        if (process.env.NODE_ENV === 'production') require('newrelic');
 
-With the above methodology, you'll be forced to push a code change for something that should be configuration driven.
+    > With the above methodology, you'll be forced to push code to change behavior that should be configuration driven. See **The Twelve-Factor App** page titled [Store config in the environment].
 
-See **The Twelve-Factor App** page titled [Store config in the environment](http://12factor.net/config).
+0. You avoid configuring a `newrelic.js` file for each app and start with sane defaults
+
+        NEW_RELIC_HOME = Project Root Directory
+        NEW_RELIC_ENABLED = true
+        NEW_RELIC_APP_NAME = `package.name` + `-` + `process.env.NODE_ENV`
+        NEW_RELIC_LOG_LEVEL = 'info'
 
 ## How it works
 
-- You set environment variables:
-  - `NEW_RELIC_LICENSE_KEY`
-  - `NEW_RELIC_ENVIRONMENTS`
-- Initialize with:
-  - `require('env-newrelic')()`.
-  - or `var newrelic = require('env-newrelic')()`.
+##### Enable
 
-## Defaults
+Set the `NEW_RELIC_LICENSE_KEY` environment variable.
 
-Once initialized, the following the following environment variables will be set:
+##### Disable
 
-    NEW_RELIC_HOME = PACKAGE ROOT
-    NEW_RELIC_ENABLED = true
-    NEW_RELIC_APP_NAME = package.name
-    NEW_RELIC_LOG_LEVEL = 'info'
-    NEW_RELIC_NO_CONFIG_FILE = true
+Set the `NEW_RELIC_DISABLED` environment variable to a truthy value (i.e. `true`, `yes`, `1`, etc.).
 
-> `NEW_RELIC_NO_CONFIG_FILE` is `true` if a `newrelic.js` file is found in your package root.
+##### Initialize
 
-A list of more environment variables can be found in the documentation page [Configuring Node.js with environment variables](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/configuring-nodejs-environment-variables).
+    require('env-newrelic')()
+    # or
+    var newrelic = require('env-newrelic')()
+
+> `NEW_RELIC_NO_CONFIG_FILE` will be set to `true` if a `newrelic.js` file is found in your package root.
+
+A list of more environment variables can be found in the documentation page [Configuring Node.js with environment variables].
 
 ## Overrides (newrelic.js)
 
 While the environment variables make using a `newrelic.js` file optional, there may be situations where you need it. A list of more configuration parameters can be found in the documentation page [Node.js agent configuration](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration).
 
-## Example
+## Example Configuration
 
-For most common scenarios, a `newrelic.js` file is not needed and can be configured as follows:
+For most apps, a `newrelic.js` file is not needed
 
 ###### .env
 
-    NEW_RELIC_ENVIRONMENTS="production,staging"
     NEW_RELIC_LICENSE_KEY="…"
 
-###### add `env-newrelic` to your program.
+###### .env.test
 
-    require('env-newrelic');
+    NEW_RELIC_DISABLED=true
 
-###### Start your program with `NODE_ENV` set to a value in `NEW_RELIC_ENVIRONMENTS`.
+## More Configuration
 
-    NODE_ENV=staging npm start
+- [Configuring Node.js with environment variables]
+- [Store config in the environment]
 
 ## License
 
   [MIT](license)
+
+
+[Configuring Node.js with environment variables]: https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/configuring-nodejs-environment-variables
+[Store config in the environment]: http://12factor.net/config

--- a/test.js
+++ b/test.js
@@ -22,20 +22,36 @@ if (!process.env.NODE_ENV) {
 }
 
 function reset() {
-  delete process.env.NEW_RELIC_ENVIRONMENTS;
+  delete process.env.NEW_RELIC_ENABLED;
+  delete process.env.NEW_RELIC_DISABLED;
   delete process.env.NEW_RELIC_LICENSE_KEY;
 }
 
 function enable() {
-  process.env.NEW_RELIC_ENVIRONMENTS = process.env.NODE_ENV;
   process.env.NEW_RELIC_LICENSE_KEY = process.env.LICENSE_KEY;
+}
+
+function disable() {
+  delete process.env.NEW_RELIC_ENABLED;
+  process.env.NEW_RELIC_DISABLED = true;
 }
 
 /*!
  * tests.
  */
 
-test('disabled by default', function (t) {
+test('enabled by default', function (t) {
+  enable();
+  var agent = newrelic();
+
+  t.assert(process.env.NEW_RELIC_ENABLED);
+
+  reset();
+  t.end();
+});
+
+test('disabled when NEW_RELIC_DISABLED is set', function (t) {
+  disable();
   var agent = newrelic();
 
   t.false(process.env.NEW_RELIC_ENABLED);


### PR DESCRIPTION
- application name defaults to `package.name` + `-` + `process.env.NODE_ENV`.
- dropped `env-allowed` package.
- better documentation.
- tests.
